### PR TITLE
removing quiet potential maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,3 +58,4 @@ extra:
     - gonuke
     - bam241
     - kkiesling
+    - opotowsky

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,3 @@ extra:
     - gonuke
     - bam241
     - kkiesling
-    - a-co
-    - opotowsky
-    - katyhuff
-    - pshriwise


### PR DESCRIPTION
this removes potential maintainer that did not directly agree to maintain the pyne conda feedstock.


@kkiesling this should be the missing piece for our first pyne conda PR to be merged.